### PR TITLE
Extract IP address API to an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ docker run --name dns-o-matic -e USERNAME=foo -e PASSWORD=bar ammmze/dns-o-matic
 | `WILDCARD` | `NOCNG` | The `wildcard` parameter passed to the [dns-o-matic api](http://dnsomatic.com/wiki/api) |
 | `MX` | `NOCNG` | The `mx` parameter passed to the [dns-o-matic api](http://dnsomatic.com/wiki/api) |
 | `BACKMX` | `NOCNG` | The `backmx` parameter passed to the [dns-o-matic api](http://dnsomatic.com/wiki/api) |
+| `IP_ADDR_PROVIDER` | http://myip.dnsomatic.com/ | Web API that provides the current public IP address to the client. Manually modify if default provider does not respond with 200 OK. Example alternative values: https://api.ipify.org and https://bot.whatismyipaddress.com |

--- a/dns-o-matic.sh
+++ b/dns-o-matic.sh
@@ -6,6 +6,7 @@ WILDCARD=${WILDCARD:-NOCHG}
 MX=${MX:-NOCHG}
 BACKMX=${BACKMX:-NOCHG}
 DELAY=${DELAY:-1h}
+IP_ADDR_PROVIDER=${IP_ADDR_PROVIDER:-"http://myip.dnsomatic.com/"}
 
 IP_FILE=${CONFIG_DIR}/dnsomatic.myip
 
@@ -24,7 +25,7 @@ trap cleanup SIGINT SIGTERM
 
 while true; do
     # fetch your current ip address
-    NEW_IP=$(curl -s http://myip.dnsomatic.com/)
+    NEW_IP=$(curl -s "${IP_ADDR_PROVIDER}")
     OLD_IP=$(test -f "${IP_FILE}" && cat "${IP_FILE}")
 
     echo OLD IP: ${OLD_IP}


### PR DESCRIPTION
## Background

`dns-o-matic.sh` hardcodes the API URL that provides the public IP address to the client. Currently it is hardcoded to http://myip.dnsomatic.com/

## Problem

http://myip.dnsomatic.com/ is unreliable. Sometimes it responds with a [HTTP 429: Too Many Requests](https://httpstatuses.com/429). If this occurs, `dns-o-matic.sh` does not behave as expected because it does not handle HTTP errors.

I believe the server is rate limiting users globally (not per IP address). Changing the `DELAY` variable to a longer time-span does not resolve the issue.

### Repro Steps

1. Visit http://myip.dnsomatic.com/
2. Refresh the page 5-10 times.

At least 2 of these 10 refreshes respond with a HTTP 429.

_This was noticed on 11pm on 5/18/2019 and 10am on 5/19/2019. Error rate may vary based on day and time._

## Proposed Solution

Extract the API URL to a environment variable. This allows developers to specify an alternate API that is more reliable.

Example alternative APIs:
- https://api.ipify.org
- https://bot.whatismyipaddress.com

The default value is still http://myip.dnsomatic.com/. Developers must manually specify an alternative if the default value is unreliable.

### Changes Made

- Extract API URL to an environment variable
- Set up a default value
- Add documentation

## Future Work

Note that the **Proposed Solution** is a work-around to temporarily resolve the issue. The better, long-term fix would be to add HTTP status code handling to `dns-o-matic.sh`.